### PR TITLE
Asciidoc: inline code (monospace)

### DIFF
--- a/themes/palenight-italic.json
+++ b/themes/palenight-italic.json
@@ -1213,7 +1213,7 @@
     },
     {
       "name": "Markup Raw Code + others",
-      "scope": "markup.inline.raw",
+      "scope": ["markup.inline.raw", "markup.raw.monospace"],
       "settings": {
         "foreground": "#80CBC4"
       }

--- a/themes/palenight-mild-contrast.json
+++ b/themes/palenight-mild-contrast.json
@@ -1213,7 +1213,7 @@
     },
     {
       "name": "Markup Raw Code + others",
-      "scope": "markup.inline.raw",
+      "scope": ["markup.inline.raw", "markup.raw.monospace"],
       "settings": {
         "foreground": "#80CBC4"
       }

--- a/themes/palenight-operator.json
+++ b/themes/palenight-operator.json
@@ -1213,7 +1213,7 @@
     },
     {
       "name": "Markup Raw Code + others",
-      "scope": "markup.inline.raw",
+      "scope": ["markup.inline.raw", "markup.raw.monospace"],
       "settings": {
         "foreground": "#80CBC4"
       }

--- a/themes/palenight.json
+++ b/themes/palenight.json
@@ -1213,7 +1213,7 @@
     },
     {
       "name": "Markup Raw Code + others",
-      "scope": "markup.inline.raw",
+      "scope": ["markup.inline.raw", "markup.raw.monospace"],
       "settings": {
         "foreground": "#80CBC4"
       }


### PR DESCRIPTION
Hello,

I added the inline code markup for asciidoc:
![image](https://user-images.githubusercontent.com/763200/95049603-5bf79c00-06ea-11eb-8eb2-50f67a0c7ed1.png)

I didn't see any impact on other languages.

Thank you!